### PR TITLE
Set a max-width size for images

### DIFF
--- a/tutorial/tutorial.css
+++ b/tutorial/tutorial.css
@@ -18,6 +18,10 @@ code {
     padding-left: 10px;
 }
 
+img {
+    max-width: 100%;
+}
+
 .type-this {
     font-weight: 900;
 }


### PR DESCRIPTION
In the tutorial + workshop mode, the images are too big which makes the tweets hard to read. This sets a max-width to make it nice and flexible.
## Before

![image](https://cloud.githubusercontent.com/assets/1860176/16432176/dda3549a-3d51-11e6-82a6-08d61c33cd5a.png)
## After

![image](https://cloud.githubusercontent.com/assets/1860176/16432155/ce4d7c6e-3d51-11e6-86a3-d6513f009cff.png)
